### PR TITLE
chore: makefile for building binary and upload to S3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: default
+
+default: pull-request-ci
+
+pipeline-build-amd64:
+	cargo build --release --features bpf \
+		&& ./package.sh amd64/rezolus.tar.gz target/release/rezolus \
+
+pipeline-build-arm64v8:
+	/sbin/bpftool btf dump file /sys/kernel/btf/vmlinux format c > src/common/bpf/vmlinux.h \
+		&& cargo build --release --features bpf \
+		&& ./package.sh arm64v8/rezolus.tar.gz target/release/rezolus \
+
+pipeline-build:
+	echo "NOOP for pipeline-build. Invoke arch-specific Makefile targets instead."
+
+pipeline-synth:
+	echo "NOOP for pipeline-synth because we have no infrastructure."
+
+pull-request-ci:
+	cargo fmt -- --check \
+		&& cargo clippy --all-targets --all-features -- -D warnings -W clippy::unwrap_used -W clippy::todo -W clippy::panic_in_result_fn -W clippy::expect_used \
+		&& cargo build --release --features bpf 
+

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Usage: ./package.sh $tar_ball_name $bin_path
+# This script will create a tar ball for the specified arch.
+
+set -e
+set -x
+
+DESTINATION="packaging"
+WORK_DIR="_packaging_internal"
+
+tar_ball_name=$1
+bin_path=$2
+
+if [ -z "$tar_ball_name" ]
+then
+  echo "ERROR: ./package.sh requires the first positional param to be the name of the tar ball."
+  exit 1
+fi
+
+if [ -z "$bin_path" ]
+then
+  echo "ERROR: ./package.sh requires the second positional param to be the path to a binary."
+  exit 1
+fi
+
+rm -rf $WORK_DIR
+mkdir -p $WORK_DIR
+cp $bin_path $WORK_DIR/
+
+mkdir -p $(dirname "$DESTINATION/$tar_ball_name")
+
+pushd $WORK_DIR
+  tar -czvf ../$DESTINATION/$tar_ball_name *
+popd
+
+rm -rf $WORK_DIR


### PR DESCRIPTION
We are going to upload the rezolus binary to S3 via pipelines.
This way we can use the rezolus and run it in ms2 or mr2 whenever we need them.

There is another PR in pipeline-of-pipelines that uses the makefile here:
https://github.com/momentohq/pipeline-of-pipelines/pull/642
So this makefile will need to be merged first before that PR can be merged.
