### PR TITLE
fix: removing dump for arm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,11 @@
 default: pull-request-ci
 
 pipeline-build-amd64:
-	cargo build --release --features bpf \
+	cargo build --release \
 		&& ./package.sh amd64/rezolus.tar.gz target/release/rezolus \
 
 pipeline-build-arm64v8:
-	/usr/local/bin/bpftool btf dump file /sys/kernel/btf/vmlinux format c > src/common/bpf/vmlinux.h \
-		&& cargo build --release --features bpf \
+	cargo build --release \
 		&& ./package.sh arm64v8/rezolus.tar.gz target/release/rezolus \
 
 pipeline-build:


### PR DESCRIPTION
The upstream has a fix for arm64v8. No need to do special dump.

