### PR TITLE
chore: merge upstream rezolus v3.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+## [3.14.0] - 2024-04-03
+
+## Changed
+
+- metriken crates updated which changes the msgpack output. (#224)
+
+## Fixed
+
+- Dependency updates to address RUSTSEC-2024-0332.
+
 ## [3.13.0] - 2024-04-01
 
 ## Changed
@@ -207,7 +217,8 @@
 - Rewritten implementation of Rezolus using libbpf-rs and perf-event2 to provide
   a more modern approach to BPF and Perf Event instrumentation. 
 
-[unreleased]: https://github.com/iopsystems/rezolus/compare/v3.13.0...HEAD
+[unreleased]: https://github.com/iopsystems/rezolus/compare/v3.14.0...HEAD
+[3.14.0]: https://github.com/iopsystems/rezolus/compare/v3.13.0...v3.14.0
 [3.13.0]: https://github.com/iopsystems/rezolus/compare/v3.12.0...v3.13.0
 [3.12.0]: https://github.com/iopsystems/rezolus/compare/v3.11.0...v3.12.0
 [3.11.0]: https://github.com/iopsystems/rezolus/compare/v3.10.3...v3.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+## [3.14.1] - 2024-04-16
+
+## Fixed
+
+- CPU usage reporting via BPF would report CPU as always idle on some systems.
+  (#233)
+
 ## [3.14.0] - 2024-04-03
 
 ## Changed
@@ -217,7 +224,8 @@
 - Rewritten implementation of Rezolus using libbpf-rs and perf-event2 to provide
   a more modern approach to BPF and Perf Event instrumentation. 
 
-[unreleased]: https://github.com/iopsystems/rezolus/compare/v3.14.0...HEAD
+[unreleased]: https://github.com/iopsystems/rezolus/compare/v3.14.1...HEAD
+[3.14.1]: https://github.com/iopsystems/rezolus/compare/v3.14.0...v3.14.1
 [3.14.0]: https://github.com/iopsystems/rezolus/compare/v3.13.0...v3.14.0
 [3.13.0]: https://github.com/iopsystems/rezolus/compare/v3.12.0...v3.13.0
 [3.12.0]: https://github.com/iopsystems/rezolus/compare/v3.11.0...v3.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+## [3.14.2] - 2024-04-18
+
+## Fixed
+
+- CPU usage for soft and hard irq was incorrectly reported. (#236)
+
 ## [3.14.1] - 2024-04-16
 
 ## Fixed
@@ -224,7 +230,8 @@
 - Rewritten implementation of Rezolus using libbpf-rs and perf-event2 to provide
   a more modern approach to BPF and Perf Event instrumentation. 
 
-[unreleased]: https://github.com/iopsystems/rezolus/compare/v3.14.1...HEAD
+[unreleased]: https://github.com/iopsystems/rezolus/compare/v3.14.2...HEAD
+[3.14.2]: https://github.com/iopsystems/rezolus/compare/v3.14.1...v3.14.2
 [3.14.1]: https://github.com/iopsystems/rezolus/compare/v3.14.0...v3.14.1
 [3.14.0]: https://github.com/iopsystems/rezolus/compare/v3.13.0...v3.14.0
 [3.13.0]: https://github.com/iopsystems/rezolus/compare/v3.12.0...v3.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,18 @@
 ## [Unreleased]
 
+## [3.13.0] - 2024-04-01
+
+## Changed
+
+- Memory sampler was reporting memory usage stats in KiB, but with bytes for the
+  unit metadata. This change corrects the sampler to report memory usage in
+  bytes. This fix is disruptive as it will cause the memory stats to change.
+  (#222)
+
 ## [3.12.0] - 2024-03-28
 
 ## Added
+
 - MacOS cpu usage sampling. (#203)
 - Metric unit annotations are added and exposed as metadata.
 - Logs version number on startup. (#213)
@@ -197,7 +207,8 @@
 - Rewritten implementation of Rezolus using libbpf-rs and perf-event2 to provide
   a more modern approach to BPF and Perf Event instrumentation. 
 
-[unreleased]: https://github.com/iopsystems/rezolus/compare/v3.12.0...HEAD
+[unreleased]: https://github.com/iopsystems/rezolus/compare/v3.13.0...HEAD
+[3.13.0]: https://github.com/iopsystems/rezolus/compare/v3.12.0...v3.13.0
 [3.12.0]: https://github.com/iopsystems/rezolus/compare/v3.11.0...v3.12.0
 [3.11.0]: https://github.com/iopsystems/rezolus/compare/v3.10.3...v3.11.0
 [3.10.3]: https://github.com/iopsystems/rezolus/compare/v3.10.2...v3.10.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,7 +1494,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rezolus"
-version = "3.12.1-alpha.0"
+version = "3.13.0"
 dependencies = [
  "backtrace",
  "chrono",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "systeminfo"
-version = "3.12.1-alpha.0"
+version = "3.13.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,9 +600,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "h2"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -1521,6 +1521,7 @@ dependencies = [
  "backtrace",
  "chrono",
  "clap",
+ "h2",
  "histogram 0.10.0",
  "humantime",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rezolus"
-version = "3.14.1"
+version = "3.14.2-alpha.0"
 dependencies = [
  "backtrace",
  "chrono",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "systeminfo"
-version = "3.14.1"
+version = "3.14.2-alpha.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "metriken-exposition"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b9515f2f3608808aad0ecac792f0c20e675cf9abdda2a16f6a9e669bb9ec23"
+checksum = "51211be05b38efe9bd8a4af3c2346e8f3c32b4818582a5412bb2c1f930e03892"
 dependencies = [
  "chrono",
  "histogram",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rezolus"
-version = "3.14.1-alpha.0"
+version = "3.14.1"
 dependencies = [
  "backtrace",
  "chrono",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "systeminfo"
-version = "3.14.1-alpha.0"
+version = "3.14.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,7 +1521,6 @@ dependencies = [
  "backtrace",
  "chrono",
  "clap",
- "h2",
  "histogram 0.10.0",
  "humantime",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,7 +1494,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rezolus"
-version = "3.13.0"
+version = "3.13.1-alpha.0"
 dependencies = [
  "backtrace",
  "chrono",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "systeminfo"
-version = "3.13.0"
+version = "3.13.1-alpha.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,6 +671,15 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b634390eb8a63662e127836d4e2f26d7ae930600d4e05ee0fd85a009eeb1175"
 dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "histogram"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4d3bddd75a32b17e75762f128ffc7a33158b933b6eb27424da9be4a58f30eb9"
+dependencies = [
  "serde",
  "thiserror",
 ]
@@ -968,7 +977,20 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9868467c2c6c455c1c7707c7eff2abd55d7ecf6a5bcc29ec7ca5cee8abdd096d"
 dependencies = [
- "histogram",
+ "histogram 0.9.1",
+ "metriken-core",
+ "metriken-derive",
+ "once_cell",
+ "parking_lot",
+]
+
+[[package]]
+name = "metriken"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0bad9aa443621ae4972578da55b7f3c24d930cc1491551a8f989edead4762c"
+dependencies = [
+ "histogram 0.10.0",
  "metriken-core",
  "metriken-derive",
  "once_cell",
@@ -1000,13 +1022,13 @@ dependencies = [
 
 [[package]]
 name = "metriken-exposition"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51211be05b38efe9bd8a4af3c2346e8f3c32b4818582a5412bb2c1f930e03892"
+checksum = "668934cb4bd14f41e8d98a447ee237c76fc19ef0b935d5127026121a096ea86e"
 dependencies = [
  "chrono",
- "histogram",
- "metriken",
+ "histogram 0.10.0",
+ "metriken 0.6.0",
  "rmp-serde",
  "serde",
 ]
@@ -1499,7 +1521,7 @@ dependencies = [
  "backtrace",
  "chrono",
  "clap",
- "histogram",
+ "histogram 0.10.0",
  "humantime",
  "lazy_static",
  "libbpf-cargo",
@@ -1508,7 +1530,7 @@ dependencies = [
  "libc",
  "linkme",
  "memmap2 0.5.10",
- "metriken",
+ "metriken 0.6.0",
  "metriken-exposition",
  "num_cpus",
  "nvml-wrapper",
@@ -1536,7 +1558,7 @@ dependencies = [
  "ahash",
  "clocksource",
  "log",
- "metriken",
+ "metriken 0.5.1",
  "mpmc",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,7 +1516,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rezolus"
-version = "3.13.1-alpha.0"
+version = "3.14.0"
 dependencies = [
  "backtrace",
  "chrono",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "systeminfo"
-version = "3.13.1-alpha.0"
+version = "3.14.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,9 +131,9 @@ checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "async-compression"
-version = "0.3.15"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+checksum = "07dbbf24db18d609b1462965249abdf49129ccad073ec257da372adc83259c60"
 dependencies = [
  "brotli",
  "flate2",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.5.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+checksum = "125740193d7fee5cc63ab9e16c2fdc4e07c74ba755cc53b327d6ea029e9fc569"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.5.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+checksum = "65622a320492e09b5e0ac436b14c54ff68199bac392d0e89a6832c4518eea525"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "1fd97381a8cc6493395a5afc4c691c1084b3768db713b73aa215217aa245d153"
 
 [[package]]
 name = "cfg-if"
@@ -583,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -609,7 +609,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap",
  "slab",
  "tokio",
@@ -632,7 +632,7 @@ dependencies = [
  "base64",
  "bytes",
  "headers-core",
- "http",
+ "http 0.2.12",
  "httpdate",
  "mime",
  "sha1",
@@ -644,7 +644,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+ "http 0.2.12",
 ]
 
 [[package]]
@@ -696,13 +696,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
  "pin-project-lite",
 ]
 
@@ -735,7 +746,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.12",
  "http-body",
  "httparse",
  "httpdate",
@@ -870,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "libbpf-sys"
-version = "1.3.0+v1.3.0"
+version = "1.4.0+v1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e68987fe8f2dd7b76930f800a4e5b958c766171fc3a7c33dd67c06a0f1e801"
+checksum = "a4ee5f6d35341ad5d492fd92466c45ff11d6e8104ffa8208f62450875c93e258"
 dependencies = [
  "cc",
  "nix 0.27.1",
@@ -1084,7 +1095,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "memchr",
@@ -1604,19 +1615,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64",
-]
-
-[[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
 
 [[package]]
 name = "ryu"
@@ -1980,21 +1982,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-tungstenite"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
 dependencies = [
  "futures-util",
  "log",
@@ -2095,14 +2086,14 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
 dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 1.1.0",
  "httparse",
  "log",
  "rand",
@@ -2208,16 +2199,16 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e92e22e03ff1230c03a1a8ee37d2f89cd489e2e541b7550d6afad96faed169"
+checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
 dependencies = [
  "async-compression",
  "bytes",
  "futures-channel",
  "futures-util",
  "headers",
- "http",
+ "http 0.2.12",
  "hyper",
  "log",
  "mime",
@@ -2225,13 +2216,11 @@ dependencies = [
  "multer",
  "percent-encoding",
  "pin-project",
- "rustls-pemfile",
  "scoped-tls",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
  "tower-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
 name = "async-compression"
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd97381a8cc6493395a5afc4c691c1084b3768db713b73aa215217aa245d153"
+checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
 
 [[package]]
 name = "cfg-if"
@@ -288,9 +288,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -454,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.33"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
@@ -1441,18 +1441,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "a56dea16b0a29e94408b9aa5e2940a4eedbd128a1ba20e8f7ae60fd3d465af0e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1706,9 +1706,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1907,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -1928,9 +1928,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,7 +1516,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rezolus"
-version = "3.14.0"
+version = "3.14.1-alpha.0"
 dependencies = [
  "backtrace",
  "chrono",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "systeminfo"
-version = "3.14.0"
+version = "3.14.1-alpha.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,7 +1494,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rezolus"
-version = "3.12.0"
+version = "3.12.1-alpha.0"
 dependencies = [
  "backtrace",
  "chrono",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "systeminfo"
-version = "3.12.0"
+version = "3.12.1-alpha.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rezolus"
-version = "3.14.2-alpha.0"
+version = "3.14.2"
 dependencies = [
  "backtrace",
  "chrono",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "systeminfo"
-version = "3.14.2-alpha.0"
+version = "3.14.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "backtrace"
@@ -288,9 +288,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.35"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
@@ -931,9 +931,9 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memmap2"
@@ -1335,9 +1335,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -1488,9 +1488,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rezolus"
@@ -1671,9 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -1824,9 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "syscall-numbers"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96d8ea672036889f79f237aa73373d2a97145f5eb9612a336707c1627d1922"
+checksum = "084e382bf467cd3381fdec080d883505792ee0d16a004b1b090abf2db5dc2a29"
 
 [[package]]
 name = "sysconf"
@@ -1929,9 +1929,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ humantime = "2.1.0"
 lazy_static = "1.4.0"
 libc = "0.2.147"
 linkme = "0.3.15"
-metriken =  "0.5.1"
-metriken-exposition = { version = "0.4.0", features = ["serde", "msgpack"] }
+metriken =  "0.6.0"
+metriken-exposition = { version = "0.5.0", features = ["serde", "msgpack"] }
 memmap2 = "0.5.10"
 num_cpus = "1.16.0"
 once_cell = "1.18.0"
@@ -34,7 +34,7 @@ toml = "0.7.6"
 walkdir = "2.3.3"
 warp = { version = "0.3.6", features = ["compression"] }
 serde_repr = "0.1.18"
-histogram = { version = "0.9.0", features = ["serde"] }
+histogram = { version = "0.10.0", features = ["serde"] }
 chrono = { version = "0.4.33", features = ["serde"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 description = "High resolution systems performance telemetry agent"
 
 [workspace.package]
-version = "3.13.1-alpha.0"
+version = "3.14.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = "1.4.0"
 libc = "0.2.147"
 linkme = "0.3.15"
 metriken =  "0.5.1"
-metriken-exposition = { version = "0.2.0", features = ["serde", "msgpack"] }
+metriken-exposition = { version = "0.4.0", features = ["serde", "msgpack"] }
 memmap2 = "0.5.10"
 num_cpus = "1.16.0"
 once_cell = "1.18.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 description = "High resolution systems performance telemetry agent"
 
 [workspace.package]
-version = "3.12.0"
+version = "3.12.1-alpha.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,6 @@ warp = { version = "0.3.6", features = ["compression"] }
 serde_repr = "0.1.18"
 histogram = { version = "0.10.0", features = ["serde"] }
 chrono = { version = "0.4.33", features = ["serde"] }
-# For RUSTSEC-2024-0332; remove once warp is updated
-h2 = "0.3.26"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libbpf-rs = { version = "0.21.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 description = "High resolution systems performance telemetry agent"
 
 [workspace.package]
-version = "3.13.0"
+version = "3.13.1-alpha.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 description = "High resolution systems performance telemetry agent"
 
 [workspace.package]
-version = "3.14.0"
+version = "3.14.1-alpha.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 description = "High resolution systems performance telemetry agent"
 
 [workspace.package]
-version = "3.14.2-alpha.0"
+version = "3.14.2"
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 description = "High resolution systems performance telemetry agent"
 
 [workspace.package]
-version = "3.14.1-alpha.0"
+version = "3.14.1"
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 description = "High resolution systems performance telemetry agent"
 
 [workspace.package]
-version = "3.12.1-alpha.0"
+version = "3.13.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ warp = { version = "0.3.6", features = ["compression"] }
 serde_repr = "0.1.18"
 histogram = { version = "0.10.0", features = ["serde"] }
 chrono = { version = "0.4.33", features = ["serde"] }
+# For RUSTSEC-2024-0332; remove once warp is updated
+h2 = "0.3.26"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libbpf-rs = { version = "0.21.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 description = "High resolution systems performance telemetry agent"
 
 [workspace.package]
-version = "3.14.1"
+version = "3.14.2-alpha.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/src/common/bpf/mod.rs
+++ b/src/common/bpf/mod.rs
@@ -3,6 +3,7 @@ use metriken::DynBoxedMetric;
 use metriken::RwLockHistogram;
 use ouroboros::*;
 use std::os::fd::{AsFd, AsRawFd, FromRawFd};
+use std::sync::Arc;
 
 pub use libbpf_rs::skel::{OpenSkel, Skel, SkelBuilder};
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -2,10 +2,9 @@
 pub mod bpf;
 
 pub mod classic;
+pub mod units;
 
 mod nop;
-
-use std::sync::Arc;
 
 use metriken::AtomicHistogram;
 use metriken::LazyCounter;

--- a/src/common/units.rs
+++ b/src/common/units.rs
@@ -1,0 +1,11 @@
+#![allow(dead_code)]
+
+// Time units with base unit as nanoseconds
+pub const SECONDS: u64 = 1_000 * MILLISECONDS;
+pub const MILLISECONDS: u64 = 1_000 * MICROSECONDS;
+pub const MICROSECONDS: u64 = 1_000 * NANOSECONDS;
+pub const NANOSECONDS: u64 = 1;
+
+// Data (IEC) with base unit as bytes - typically used for memory
+pub const KIBIBYTES: u64 = 1024 * BYTES;
+pub const BYTES: u64 = 1;

--- a/src/samplers/cpu/linux/usage/bpf.rs
+++ b/src/samplers/cpu/linux/usage/bpf.rs
@@ -46,6 +46,7 @@ pub struct CpuUsage {
     online_cores_next: Instant,
 }
 
+const IDLE_CPUTIME_INDEX: usize = 5;
 impl CpuUsage {
     pub fn new(config: &Config) -> Result<Self, ()> {
         let builder = ModSkelBuilder::default();
@@ -75,10 +76,10 @@ impl CpuUsage {
             Counter::new(&CPU_USAGE_USER, Some(&CPU_USAGE_USER_HISTOGRAM)),
             Counter::new(&CPU_USAGE_NICE, Some(&CPU_USAGE_NICE_HISTOGRAM)),
             Counter::new(&CPU_USAGE_SYSTEM, Some(&CPU_USAGE_SYSTEM_HISTOGRAM)),
+            Counter::new(&CPU_USAGE_SOFTIRQ, Some(&CPU_USAGE_SOFTIRQ_HISTOGRAM)),
+            Counter::new(&CPU_USAGE_IRQ, Some(&CPU_USAGE_IRQ_HISTOGRAM)),
             Counter::new(&CPU_USAGE_IDLE, Some(&CPU_USAGE_IDLE_HISTOGRAM)),
             Counter::new(&CPU_USAGE_IO_WAIT, Some(&CPU_USAGE_IO_WAIT_HISTOGRAM)),
-            Counter::new(&CPU_USAGE_IRQ, Some(&CPU_USAGE_IRQ_HISTOGRAM)),
-            Counter::new(&CPU_USAGE_SOFTIRQ, Some(&CPU_USAGE_SOFTIRQ_HISTOGRAM)),
             Counter::new(&CPU_USAGE_STEAL, Some(&CPU_USAGE_STEAL_HISTOGRAM)),
             Counter::new(&CPU_USAGE_GUEST, Some(&CPU_USAGE_GUEST_HISTOGRAM)),
             Counter::new(&CPU_USAGE_GUEST_NICE, Some(&CPU_USAGE_GUEST_NICE_HISTOGRAM)),
@@ -90,10 +91,10 @@ impl CpuUsage {
             "user",
             "nice",
             "system",
+            "softirq",
+            "irq",
             "idle",
             "io_wait",
-            "irq",
-            "softirq",
             "steal",
             "guest",
             "guest_nice",
@@ -176,7 +177,8 @@ impl CpuUsage {
             let sum_now: u64 = self.percpu_counters.sum(cpu).unwrap_or(0);
             let busy_delta = sum_now.wrapping_sub(*sum_prev);
             let idle_delta = elapsed.as_nanos() as u64 - busy_delta;
-            self.percpu_counters.add(cpu, 3, idle_delta);
+            self.percpu_counters
+                .add(cpu, IDLE_CPUTIME_INDEX, idle_delta);
             *sum_prev += busy_delta + idle_delta;
         }
 
@@ -244,10 +246,10 @@ fn sum() -> u64 {
         &CPU_USAGE_USER,
         &CPU_USAGE_NICE,
         &CPU_USAGE_SYSTEM,
+        &CPU_USAGE_SOFTIRQ,
+        &CPU_USAGE_IRQ,
         &CPU_USAGE_IDLE,
         &CPU_USAGE_IO_WAIT,
-        &CPU_USAGE_IRQ,
-        &CPU_USAGE_SOFTIRQ,
         &CPU_USAGE_STEAL,
         &CPU_USAGE_GUEST,
         &CPU_USAGE_GUEST_NICE,

--- a/src/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/samplers/cpu/linux/usage/mod.bpf.c
@@ -10,14 +10,17 @@
 #define COUNTER_GROUP_WIDTH 16
 #define MAX_CPUS 1024
 
-// counters for cpu usage
+#define IDLE_STAT_INDEX 5
+#define IOWAIT_STAT_INDEX 6
+
+// cpu usage stat index (https://elixir.bootlin.com/linux/v6.9-rc4/source/include/linux/kernel_stat.h#L20)
 // 0 - user
 // 1 - nice
 // 2 - system
-// 3 - idle - *NOTE* this will not increment. User-space must calculate it
-// 4 - iowait
-// 5 - irq
-// 6 - softirq
+// 3 - softirq
+// 4 - irq
+// 5 - idle - *NOTE* this will not increment. User-space must calculate it
+// 6 - iowait
 // 7 - steal
 // 8 - guest
 // 9 - guest_nice
@@ -47,7 +50,9 @@ int account_delta(u64 delta, u32 usage_idx)
 SEC("kprobe/cpuacct_account_field")
 int BPF_KPROBE(cpuacct_account_field_kprobe, void *task, u32 index, u64 delta)
 {
-	if (index == 3) {
+  // ignore both the idle and the iowait counting since both count the idle time
+  // https://elixir.bootlin.com/linux/v6.9-rc4/source/kernel/sched/cputime.c#L227
+	if (index == IDLE_STAT_INDEX || index == IOWAIT_STAT_INDEX) {
 		return 0;
 	}
 

--- a/src/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/samplers/cpu/linux/usage/mod.bpf.c
@@ -44,8 +44,8 @@ int account_delta(u64 delta, u32 usage_idx)
 	return 0;
 }
 
-SEC("kprobe/__cgroup_account_cputime_field")
-int BPF_KPROBE(cgroup_account_cputime_field_kprobe, void *task, u32 index, u64 delta)
+SEC("kprobe/cpuacct_account_field")
+int BPF_KPROBE(cpuacct_account_field_kprobe, void *task, u32 index, u64 delta)
 {
 	if (index == 3) {
 		return 0;

--- a/src/samplers/memory/linux/proc_meminfo/mod.rs
+++ b/src/samplers/memory/linux/proc_meminfo/mod.rs
@@ -1,3 +1,4 @@
+use crate::common::units::KIBIBYTES;
 use crate::common::Nop;
 use crate::samplers::memory::stats::*;
 use crate::samplers::memory::*;
@@ -99,7 +100,7 @@ impl ProcMeminfo {
 
             if let Some(gauge) = self.gauges.get_mut(*parts.first().unwrap()) {
                 if let Some(Ok(v)) = parts.get(1).map(|v| v.parse::<i64>()) {
-                    gauge.set(v);
+                    gauge.set(v * KIBIBYTES as i64);
                 }
             }
         }

--- a/src/samplers/rezolus/rusage/mod.rs
+++ b/src/samplers/rezolus/rusage/mod.rs
@@ -1,11 +1,8 @@
 use super::stats::*;
 use super::*;
+use crate::common::units::{KIBIBYTES, MICROSECONDS, SECONDS};
 use crate::common::Counter;
 use crate::common::Nop;
-
-const S: u64 = 1_000_000_000;
-const US: u64 = 1_000;
-const KB: i64 = 1024;
 
 #[distributed_slice(REZOLUS_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
@@ -104,13 +101,15 @@ impl Rusage {
         if unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut rusage) } == 0 {
             self.ru_utime.set(
                 elapsed,
-                rusage.ru_utime.tv_sec as u64 * S + rusage.ru_utime.tv_usec as u64 * US,
+                rusage.ru_utime.tv_sec as u64 * SECONDS
+                    + rusage.ru_utime.tv_usec as u64 * MICROSECONDS,
             );
             self.ru_stime.set(
                 elapsed,
-                rusage.ru_stime.tv_sec as u64 * S + rusage.ru_stime.tv_usec as u64 * US,
+                rusage.ru_stime.tv_sec as u64 * SECONDS
+                    + rusage.ru_stime.tv_usec as u64 * MICROSECONDS,
             );
-            RU_MAXRSS.set(rusage.ru_maxrss * KB);
+            RU_MAXRSS.set(rusage.ru_maxrss * KIBIBYTES as i64);
             RU_MINFLT.set(rusage.ru_minflt as u64);
             RU_MAJFLT.set(rusage.ru_majflt as u64);
             RU_INBLOCK.set(rusage.ru_inblock as u64);


### PR DESCRIPTION
Upgrade rezolus to 3.14.2 to pick up bug fixes

## Change list
- begin next development iteration (#218)
- update metriken-exposition (#219)
- chore(deps): bump the cargo-dependencies group with 12 updates (#221)
- fix: report memory usage gauges in bytes (#222)
- prepare for release 3.13.0 (#223)
- begin next development iteration (#225)
- deps: update metriken
- deps: update h2 for RUSTSEC-2024-0332 (#226)
- deps: Rollback #226 and update h2 using cargo update (#227)
- prepare for release 3.14.0 (#228)
- begin next development iteration (#230)
- chore(deps): bump the cargo-dependencies group with 11 updates (#229)
- chore(deps): bump the cargo-dependencies group with 11 updates (#231)
- fix: change kprobe for cpu usage (#233)
- prepare for release 3.14.1 (#234)
- begin next development iteration (#235)
- Update the index of CPU usage counters to match cpu_usage_stat (#236)
- prepare for release 3.14.2 (#237)

