### PR TITLE
feat: use makefile to manage build dependency

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -52,7 +52,7 @@ jobs:
           # (or a compiler that supports C++17).
           # - { distro: ubuntu, release: trusty  } # LTS until Apr 2024
           # - { distro: ubuntu, release: xenial  } # LTS until Apr 2026
-          - { distro: ubuntu, release: bionic  } # LTS until Apr 2028
+          # - { distro: ubuntu, release: bionic  } # LTS until Apr 2028
           - { distro: ubuntu, release: focal   } # LTS until Apr 2030
           - { distro: ubuntu, release: jammy   } # LTS until Apr 2032
           - { distro: ubuntu, release: lunar   } # Current release

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,13 @@
 
 default: pull-request-ci
 
-pipeline-build-amd64:
-	cargo build --release \
-		&& ./package.sh amd64/rezolus.tar.gz target/release/rezolus \
+install-bpftool-arm:
+	curl -fSL "https://github.com/libbpf/bpftool/releases/download/v7.2.0/bpftool-v7.2.0-arm64.tar.gz" -o bpftool.tar.gz \
+		&& tar --extract --file bpftool.tar.gz --directory /usr/local/bin \
+		&& chmod +x /usr/local/bin/bpftool \
+		&& source ~/.bashrc
 
-pipeline-build-arm64v8:
+pipeline-build-arm64v8: install-bpftool-arm
 	cargo build --release \
 		&& ./package.sh arm64v8/rezolus.tar.gz target/release/rezolus \
 


### PR DESCRIPTION
Since we will be using default AWS build images, `bpftool` will not be installed by default. We will use `make` to manage that dependency for us. Removes x86 target
