### PR TITLE
fix: add step to install os dependencies for build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,18 @@
 
 default: pull-request-ci
 
+install-dependencies:
+	yum update -y
+	yum install cmake3 clang-devel zstd libzstd-devel -y
+	(ln -s /usr/bin/cmake3 /usr/bin/cmake) || echo "cmake already installed, nothing to do"
+
 install-bpftool-arm:
 	curl -fSL "https://github.com/libbpf/bpftool/releases/download/v7.2.0/bpftool-v7.2.0-arm64.tar.gz" -o bpftool.tar.gz \
 		&& tar --extract --file bpftool.tar.gz --directory /usr/local/bin \
 		&& chmod +x /usr/local/bin/bpftool \
 		&& source ~/.bashrc
 
-pipeline-build-arm64v8: install-bpftool-arm
+pipeline-build-arm64v8: install-dependencies install-bpftool-arm
 	cargo build --release \
 		&& ./package.sh arm64v8/rezolus.tar.gz target/release/rezolus \
 


### PR DESCRIPTION
Build failed because it was missing clang, there were a few other things we needed (from what I remember) so I'm adding them here to be safe :shrug:
