### PR TITLE
fix: bring back in cmake3 changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ default: pull-request-ci
 
 install-dependencies:
 	yum update -y
-	yum install clang-devel -y
+	yum install cmake3 clang-devel -y
+	(ln -s /usr/bin/cmake3 /usr/bin/cmake) || echo "cmake already installed, nothing to do"
 
 compile-binaries:
 	cargo --version \


### PR DESCRIPTION
Pipelines failed to build with recent release due to:

```
Compiling nvml-wrapper v0.10.0
error: failed to run custom build command for `rezolus v4.1.1 (/codebuild/output/src4002076787/src/codestar-connections.us-west-2.amazonaws.com/git-http/401011790710/us-west-2/809bfb2b-d7c2-44ce-ae49-dda3b6f54cfb/momentohq/rezolus)`
Caused by:
  process didn't exit successfully: `/codebuild/output/src4002076787/src/codestar-connections.us-west-2.amazonaws.com/git-http/401011790710/us-west-2/809bfb2b-d7c2-44ce-ae49-dda3b6f54cfb/momentohq/rezolus/target/release/build/rezolus-df546ea4da24c181/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at build.rs:55:22:
  called `Result::unwrap()` on an `Err` value: failed to build `src/samplers/blockio/linux/latency/mod.bpf.c`
  Caused by:
      0: Failed to execute clang
      1: No such file or directory (os error 2)
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
make: *** [Makefile:10: compile-binaries] Error 101
```

Therefore, we should bring back in the cmake3 plus symlink changes
